### PR TITLE
Fix wrong import and dump latest code

### DIFF
--- a/mobly/controllers/wifi/lib/hostapd_manager.py
+++ b/mobly/controllers/wifi/lib/hostapd_manager.py
@@ -206,6 +206,9 @@ class HostapdConfig:
   def update_from_wifi_config(self, wifi_config: wifi_configs.WiFiConfig):
     """Updates this object according to the `WiFiConfig` object."""
     self.set_ssid(wifi_config.ssid)
+    if wifi_config.use_random_bssid:
+      bssid = wifi_configs.generate_random_bssid()
+      self.update('bssid', bssid)
 
     # TODO: Better API is returning a dict / hostapd_conf and merge
     # it.

--- a/mobly/controllers/wifi/lib/utils.py
+++ b/mobly/controllers/wifi/lib/utils.py
@@ -102,3 +102,28 @@ def run_command(
   if (not ignore_error) and ret != 0:
     raise RuntimeError(f'Failed to run command "{cmd}" with error: {err}')
   return ret, out, err
+
+
+def convert_testbed_bool_value(value: bool | str) -> bool:
+  """Converts a raw value from testbed configuration to a bool value.
+
+  We need this method because in some trigger approaches bool values in MH
+  static testbed are transformed to strings in Mobly testbed.
+
+  Args:
+    value: The raw value from testbed configuration.
+
+  Returns:
+    The bool value.
+
+  Raises:
+    ValueError: If got invalid value.
+  """
+  if isinstance(value, bool):
+    return value
+  if isinstance(value, str):
+    if value.lower() == 'true':
+      return True
+    if value.lower() == 'false':
+      return False
+  raise ValueError(f'Invalid bool value from testbed: {value}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ maintainers = [{ name = "Minghao Li", email = "minghaoli@google.com" }]
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.11"
-version = "1.1b1"
+version = "1.1b2"
 dependencies = [
     'mobly>=1.12.2',
     'immutabledict',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,11 @@
 
 import setuptools
 
+description = (
+    'Mobly WiFi controller module for using Python code to operate network '
+    'devices in Mobly tests.'
+)
+
 install_requires = [
     'mobly>=1.12.2',
     'immutabledict',
@@ -26,16 +31,16 @@ install_requires = [
 
 setuptools.setup(
     name='mobly-wifi',
-    version='1.1b1',
+    version='1.1b2',
     author='Minghao Li',
     author_email='minghaoli@google.com',
-    description='Mobly WiFi controller module for using Python code to operate network devices in Mobly tests.',
+    description=description,
     license='Apache2.0',
     url='https://github.com/google/mobly-wifi',
-
-    packages=['mobly.controllers.wifi'],
+    packages=setuptools.find_namespace_packages(
+        include=['mobly.controllers.*']
+    ),
     package_data={'mobly.controllers.wifi': ['data/*']},
-
     install_requires=install_requires,
     python_requires='>=3.11',
 )


### PR DESCRIPTION
Dumping latest code introduce following changes:

* Support BSSID randomization.
* Support skipping AP reboot in the device initialization phase.

Tested by running BeToCQ locally.